### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@
 
 PREFIX ?= /usr/local
 
-CMD := 'for I in lang/*.po; do echo "build/locale/$$(basename $$I .po)/LC_MESSAGES/vrms-rpm.mo"; done'
-LANGS := $(shell bash -c $(CMD))
+PO_FILES := $(shell ls lang/*.po)
+MO_FILES := $(PO_FILES:lang/%.po=build/locale/%/LC_MESSAGES/vrms-rpm.mo)
 
-CMD := 'for I in man/*.man; do [ "$$I" != "man/en.man" ] && echo "$$(basename "$$I" .man)"; done'
-NON_EN_MANS := $(shell bash -c $(CMD))
+MANS := $(shell ls man/*.man)
+MAN_LANGS := $(MANS:man/%.man=%)
+NON_EN_MAN_LANGS := $(filter-out en, $(MAN_LANGS))
 
 help:
 	@echo "TARGETS:"
@@ -34,7 +35,7 @@ help:
 	@echo "    PREFIX - installation prefix (default: /usr/local)"
 
 .PHONY: build
-build: $(LANGS) build/vrms-rpm
+build: $(MO_FILES) build/vrms-rpm
 
 build/locale/%/LC_MESSAGES/vrms-rpm.mo: lang/%.po
 	mkdir -p "$(shell dirname "$@")"
@@ -69,8 +70,8 @@ install/prepare: build
 install/prepare: install/bin/vrms-rpm
 install/prepare: install/share/suve/vrms-rpm/good-licenses.txt
 install/prepare: install/share/man/man1/vrms-rpm.1
-install/prepare: $(shell for MAN in $(NON_EN_MANS); do echo "install/share/man/$$MAN/man1/vrms-rpm.1" ; done)
-	rsync -av build/*/ install
+install/prepare: $(NON_EN_MAN_LANGS:%/install/share/man/%/man1/vrms-rpm.1)
+install/prepare: $(MO_FILES:build/%=install/share/%)
 
 .PHONY: install
 install: install/prepare

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install/prepare: build
 install/prepare: install/bin/vrms-rpm
 install/prepare: install/share/suve/vrms-rpm/good-licences.txt
 install/prepare: install/share/man/man1/vrms-rpm.1
-install/prepare: $(NON_EN_MAN_LANGS:%/install/share/man/%/man1/vrms-rpm.1)
+install/prepare: $(NON_EN_MAN_LANGS:%=install/share/man/%/man1/vrms-rpm.1)
 install/prepare: $(MO_FILES:build/%=install/share/%)
 
 install: install/prepare

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ install/prepare: $(MO_FILES:build/%=install/share/%)
 
 install: install/prepare
 	mkdir -p "$(PREFIX)"
-	rsync -av install/* "$(PREFIX)"
+	cp -a install/* "$(PREFIX)"
 	rm -rf install
 
 remove: install/prepare

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "    PREFIX - installation prefix (default: /usr/local)"
 
 .PHONY: build
-build: $(LANGS) build/vrms-rpm build/usr
+build: $(LANGS) build/vrms-rpm
 
 build/locale/%/LC_MESSAGES/vrms-rpm.mo: lang/%.po
 	mkdir -p "$(shell dirname "$@")"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ clean:
 install/bin/vrms-rpm: build/vrms-rpm
 	install -vD -p -m 755 "$<" "$@"
 
-install/share/suve/vrms-rpm/good-licenses.txt:
+install/share/suve/vrms-rpm/good-licences.txt:
 	install -vD -m 644 src/good-licences.txt "$@"
 
 install/share/man/man1/vrms-rpm.1: man/en.man
@@ -67,7 +67,7 @@ install/share/locale/%: build/locale/%
 
 install/prepare: build
 install/prepare: install/bin/vrms-rpm
-install/prepare: install/share/suve/vrms-rpm/good-licenses.txt
+install/prepare: install/share/suve/vrms-rpm/good-licences.txt
 install/prepare: install/share/man/man1/vrms-rpm.1
 install/prepare: $(NON_EN_MAN_LANGS:%/install/share/man/%/man1/vrms-rpm.1)
 install/prepare: $(MO_FILES:build/%=install/share/%)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+#
+# Makefile for vrms-rpm
+# Copyright (C) 2017 Marcin "dextero" Radomski
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program (LICENCE.txt). If not, see <http://www.gnu.org/licenses/>.
+#
+
+PREFIX ?= /usr/local
+
+CMD := 'for I in lang/*.po; do echo "build/locale/$$(basename $$I .po)/LC_MESSAGES/vrms-rpm.mo"; done'
+LANGS := $(shell bash -c $(CMD))
+
+CMD := 'for I in man/*.man; do [ "$$I" != "man/en.man" ] && echo "$$(basename "$$I" .man)"; done'
+NON_EN_MANS := $(shell bash -c $(CMD))
+
+help:
+	@echo "TARGETS:"
+	@echo "    build - compile project"
+	@echo "    clean - remove compiled artifacts"
+	@echo "    install - compile & install project"
+	@echo "    remove - uninstall project"
+	@echo ""
+	@echo "VARIABLES:"
+	@echo "    PREFIX - installation prefix (default: /usr/local)"
+
+.PHONY: build
+build: $(LANGS) build/vrms-rpm build/usr
+
+build/locale/%/LC_MESSAGES/vrms-rpm.mo: lang/%.po
+	mkdir -p "$(shell dirname "$@")"
+	msgfmt --check -o "$@" "$<"
+
+# force rebuild every time, to make sure PREFIX is correct
+.PHONY: build/vrms-rpm
+build/vrms-rpm: src/vrms-rpm.sh
+	cp -p "$<" "$@"
+	sed -e 's|prog_usr="/usr"|prog_usr="/$(PREFIX)"|' -i "$@"
+
+.PHONY: clean
+clean:
+	rm -rf build
+
+install/bin/vrms-rpm: build/vrms-rpm
+	install -vD -p -m 755 "$<" "$@"
+
+install/share/suve/vrms-rpm/good-licenses.txt:
+	install -vD -m 644 src/good-licences.txt "$@"
+
+install/share/man/man1/vrms-rpm.1: man/en.man
+	install -vD -p -m 644 "$<" "$@"
+
+install/share/man/%/man1/vrms-rpm.1: man/%.man
+	install -vD -p -m 644 "$<" "$@"
+
+install/share/locale/%: build/locale/%
+	install -vD -p -m 644 "$<" "$@"
+
+install/prepare: build
+install/prepare: install/bin/vrms-rpm
+install/prepare: install/share/suve/vrms-rpm/good-licenses.txt
+install/prepare: install/share/man/man1/vrms-rpm.1
+install/prepare: $(shell for MAN in $(NON_EN_MANS); do echo "install/share/man/$$MAN/man1/vrms-rpm.1" ; done)
+	rsync -av build/* install
+
+.PHONY: install
+install: install/prepare
+	mkdir -p "$(PREFIX)"
+	rsync -av install/* "$(PREFIX)"
+	rm -rf install
+
+.PHONY: remove
+remove: install/prepare
+	find install -type f | sed -e 's|^install|$(PREFIX)|' | xargs rm -vf
+	find install -depth -type d | sed -e 's|^install|$(PREFIX)|' | xargs rmdir -v --ignore-fail-on-non-empty
+	rm -rf install

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ install/prepare: install/bin/vrms-rpm
 install/prepare: install/share/suve/vrms-rpm/good-licenses.txt
 install/prepare: install/share/man/man1/vrms-rpm.1
 install/prepare: $(shell for MAN in $(NON_EN_MANS); do echo "install/share/man/$$MAN/man1/vrms-rpm.1" ; done)
-	rsync -av build/* install
+	rsync -av build/*/ install
 
 .PHONY: install
 install: install/prepare

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ MANS := $(shell ls man/*.man)
 MAN_LANGS := $(MANS:man/%.man=%)
 NON_EN_MAN_LANGS := $(filter-out en, $(MAN_LANGS))
 
+.PHONY: build build/vrms-rpm clean install remove
+
 help:
 	@echo "TARGETS:"
 	@echo "    build - compile project"
@@ -34,7 +36,6 @@ help:
 	@echo "VARIABLES:"
 	@echo "    PREFIX - installation prefix (default: /usr/local)"
 
-.PHONY: build
 build: $(MO_FILES) build/vrms-rpm
 
 build/locale/%/LC_MESSAGES/vrms-rpm.mo: lang/%.po
@@ -42,12 +43,10 @@ build/locale/%/LC_MESSAGES/vrms-rpm.mo: lang/%.po
 	msgfmt --check -o "$@" "$<"
 
 # force rebuild every time, to make sure PREFIX is correct
-.PHONY: build/vrms-rpm
 build/vrms-rpm: src/vrms-rpm.sh
 	cp -p "$<" "$@"
 	sed -e 's|prog_usr="/usr"|prog_usr="/$(PREFIX)"|' -i "$@"
 
-.PHONY: clean
 clean:
 	rm -rf build
 
@@ -73,13 +72,11 @@ install/prepare: install/share/man/man1/vrms-rpm.1
 install/prepare: $(NON_EN_MAN_LANGS:%/install/share/man/%/man1/vrms-rpm.1)
 install/prepare: $(MO_FILES:build/%=install/share/%)
 
-.PHONY: install
 install: install/prepare
 	mkdir -p "$(PREFIX)"
 	rsync -av install/* "$(PREFIX)"
 	rm -rf install
 
-.PHONY: remove
 remove: install/prepare
 	find install -type f | sed -e 's|^install|$(PREFIX)|' | xargs rm -vf
 	find install -depth -type d | sed -e 's|^install|$(PREFIX)|' | xargs rmdir -v --ignore-fail-on-non-empty


### PR DESCRIPTION
Having a custom, non-standard build script seems absolutely proprietary. This diff fixes this by introducing a GNU Makefile instead.

There are a few semantic changes compared to build.sh:
- `usr` file (the one with `usr`/`usr/local` content) is not generated,
- `--prefix` and `--local/--global` are merged into a single PREFIX variable.

Also, `rsync` is used to recursively merge directories. Is adding that dependency OK?

I compared outputs of `./build.sh --global --prefix install-root build && ./build.sh --global --prefix install-root install` with `make PREFIX=install-root/usr install` and the directory structure seems to match. 