### PR TITLE
Makefile: add support for DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # this program (LICENCE.txt). If not, see <http://www.gnu.org/licenses/>.
 #
 
-PREFIX ?= /usr/local
+PREFIX ?= $(DESTDIR)/usr/local
 
 PO_FILES := $(shell ls lang/*.po)
 MO_FILES := $(PO_FILES:lang/%.po=build/locale/%/LC_MESSAGES/vrms-rpm.mo)
@@ -34,7 +34,7 @@ help:
 	@echo "    remove - uninstall project"
 	@echo ""
 	@echo "VARIABLES:"
-	@echo "    PREFIX - installation prefix (default: /usr/local)"
+	@echo "    PREFIX - installation prefix (default: \$$DESTDIR/usr/local)"
 	@echo "             used during build to set up file paths"
 
 build: $(MO_FILES) build/vrms-rpm

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@
 # this program (LICENCE.txt). If not, see <http://www.gnu.org/licenses/>.
 #
 
-PREFIX ?= $(DESTDIR)/usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
+
+INSTALL_ROOT := $(DESTDIR)$(PREFIX)
 
 PO_FILES := $(shell ls lang/*.po)
 MO_FILES := $(PO_FILES:lang/%.po=build/locale/%/LC_MESSAGES/vrms-rpm.mo)
@@ -34,8 +37,9 @@ help:
 	@echo "    remove - uninstall project"
 	@echo ""
 	@echo "VARIABLES:"
-	@echo "    PREFIX - installation prefix (default: \$$DESTDIR/usr/local)"
-	@echo "             used during build to set up file paths"
+	@echo "    DESTDIR - directory to store installed files in."
+	@echo "    PREFIX - installation prefix (default: /usr/local)"
+	@echo "             used during build to set up file paths."
 
 build: $(MO_FILES) build/vrms-rpm
 
@@ -74,8 +78,8 @@ install/prepare: $(NON_EN_MAN_LANGS:%=install/share/man/%/man1/vrms-rpm.1)
 install/prepare: $(MO_FILES:build/%=install/share/%)
 
 install: install/prepare
-	mkdir -p "$(PREFIX)"
-	cp -a install/* "$(PREFIX)"
+	mkdir -p "$(INSTALL_ROOT)"
+	cp -a install/* "$(INSTALL_ROOT)"
 	rm -rf install
 
 remove: install/prepare


### PR DESCRIPTION
Fixes #19 

All files are installed under `$PREFIX`, which defaults to `$DESTDIR/usr/local`. If both `DESTDIR` and `PREFIX` environment variables are set, `DESTDIR` is ignored.