### PR TITLE
Fix handling of parenthesized expressions in count_members

### DIFF
--- a/src/licences.c
+++ b/src/licences.c
@@ -167,7 +167,7 @@ static int count_members(char *licence, char *joiner_str) {
 		if(joiner == NULL) return count;
 		
 		char *openparen = strchr(licence, '(');
-		if(openparen != NULL) {
+		if(openparen != NULL && openparen < joiner) {
 			char *closingparen = find_closing_paren(openparen);
 			if(closingparen != NULL) {
 				licence = closingparen + 1;


### PR DESCRIPTION
It returned invalid value in case of inputs that contain parenthesized
expressions as non-first argument to `and` or `or` operators.

For example, following input:

    LGPLv2+ and (GPLv2 or GPLv3)

caused it to return 1 instead of 2, because the presence of left-hand
side of `and` was completely ignored.