### PR TITLE
Add "Boost-1.0" as valid name for BSL-1.0

### DIFF
--- a/licences/tweaked.txt
+++ b/licences/tweaked.txt
@@ -80,6 +80,7 @@ BitTorrent-1.1
 Bitstream Vera
 Bitstream Vera Fonts Copyright
 Boost
+Boost-1.0
 Borceux
 CAL-1.0
 CAL-1.0-Combined-Work-Exception


### PR DESCRIPTION
To prevent a false flag for a few packages in the main Fedora repositories:

```
 - librados2
   (LGPLv2.1 or LGPLv3) and CC-BY-SA-3.0 and GPLv2 and Boost-1.0 and BSD and MIT
 - librbd1
   (LGPLv2.1 or LGPLv3) and CC-BY-SA-3.0 and GPLv2 and Boost-1.0 and BSD and MIT
```

The Boost Software License 1.0 is already listed here and it's free per FSF, OSI:
https://opensource.org/licenses/BSL-1.0
https://www.gnu.org/licenses/license-list.html#boost